### PR TITLE
Check the AppContext BaseDir for files

### DIFF
--- a/Photino.NET/PhotinoWindow.cs
+++ b/Photino.NET/PhotinoWindow.cs
@@ -901,6 +901,22 @@ namespace PhotinoNET
 
             // Open a file resource string path
             string absolutePath = Path.GetFullPath(path);
+
+            // For bundled app it can be necessary to consider
+            // the app context base directory. Check there too.
+            if (File.Exists(absolutePath) == false)
+            {
+                absolutePath = $"{System.AppContext.BaseDirectory}/{path}";
+
+                // If the file does not exist on this path,
+                // send an error message to user.
+                if (File.Exists(absolutePath) == false)
+                {
+                    Console.WriteLine($"File \"{path}\" could not be found.");
+                    return this;
+                }
+            }
+
             return this.Load(new Uri(absolutePath, UriKind.Absolute));
         }
 


### PR DESCRIPTION
When running an application as a single-file published
app bundle, under certain circumstances (like in macOS),
files are not found because the application doesn't look
in the correct directory in which the resource files are
saved.

To prevent this, check whether the file exists under the
full path determined the old way. If not found, check
the app context base directory for the file as well.
If there is no matching file found still, write some error
output to console for debugging purposes. This part must
still be refined with a better way of notifying developers
about the missing file.