### PR TITLE
Fixed version WebView2

### DIFF
--- a/Photino.NET/Photino.NET.csproj
+++ b/Photino.NET/Photino.NET.csproj
@@ -15,6 +15,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Title>PhotinoNET</Title>
     <RootNamespace>PhotinoNET</RootNamespace>
+    <Configurations>Release;Debug</Configurations>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <Target Name="SetPackageVersion" DependsOnTargets="Build">
@@ -23,10 +25,39 @@
     </PropertyGroup>
   </Target>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Photino.Native" Version="2.0.19" />
+  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Debug\Photino.Native.dll" Link="Photino.Native.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Debug\Photino.Native.pdb" Link="Photino.Native.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Debug\WebView2Loader.dll" Link="WebView2Loader.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 
-  
+  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Release\Photino.Native.dll" Link="Photino.Native.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Release\Photino.Native.pdb" Link="Photino.Native.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Release\WebView2Loader.dll" Link="WebView2Loader.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+
 </Project>

--- a/Photino.NET/Photino.NET.csproj
+++ b/Photino.NET/Photino.NET.csproj
@@ -15,8 +15,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Title>PhotinoNET</Title>
     <RootNamespace>PhotinoNET</RootNamespace>
-    <Configurations>Release;Debug</Configurations>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <Target Name="SetPackageVersion" DependsOnTargets="Build">
@@ -25,39 +23,10 @@
     </PropertyGroup>
   </Target>
 
-  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Debug\Photino.Native.dll" Link="Photino.Native.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Debug\Photino.Native.pdb" Link="Photino.Native.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Debug\WebView2Loader.dll" Link="WebView2Loader.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Release\Photino.Native.dll" Link="Photino.Native.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Release\Photino.Native.pdb" Link="Photino.Native.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Include="$(ProjectDir)..\..\photino.Native\Photino.Native\x64\Release\WebView2Loader.dll" Link="WebView2Loader.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Photino.Native" Version="2.0.19" />
   </ItemGroup>
 
-
+  
 </Project>

--- a/Photino.NET/PhotinoDllImports.cs
+++ b/Photino.NET/PhotinoDllImports.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace PhotinoNET
@@ -48,6 +48,7 @@ namespace PhotinoNET
 
 
         //SET
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, SetLastError = true, CharSet = CharSet.Auto)] static extern void Photino_setWebView2RuntimePath_win32 (IntPtr instance, string webView2RuntimePath);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, SetLastError = true)] static extern void Photino_SetContextMenuEnabled(IntPtr instance, bool enabled);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, SetLastError = true)] static extern void Photino_SetDevToolsEnabled(IntPtr instance, bool enabled);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, SetLastError = true)] static extern void Photino_SetFullScreen(IntPtr instance, bool fullScreen);

--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -22,7 +22,7 @@ namespace PhotinoNET
             GrantBrowserPermissions = true,
             TemporaryFilesPathWide = IsWindowsPlatform
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Photino")
-                : null,            
+                : null,
             TemporaryFilesPath = IsWindowsPlatform
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Photino")
                 : null,
@@ -32,7 +32,7 @@ namespace PhotinoNET
             UseOsDefaultSize = true,
             Zoom = 100,
         };
-        
+
         //Pointers to the type and instance.
         private static IntPtr _nativeType = IntPtr.Zero;
         private IntPtr _nativeInstance;
@@ -505,7 +505,7 @@ namespace PhotinoNET
                 {
                     if (_nativeInstance != IntPtr.Zero)
                         throw new ApplicationException($"{nameof(tfp)} cannot be changed after Photino Window is initialized");
-                    if (IsWindowsPlatform)                    
+                    if (IsWindowsPlatform)
                         _startupParameters.TemporaryFilesPathWide = value;
                     else
                         _startupParameters.TemporaryFilesPath = value;
@@ -900,9 +900,9 @@ namespace PhotinoNET
             // For some reason the vertical position is not handled correctly.
             // Whenever a positive value is set, the window appears at the
             // very bottom of the screen and the only visible thing is the
-            // application window title bar. As a workaround we make a 
+            // application window title bar. As a workaround we make a
             // negative value out of the vertical position to "pull" the window up.
-            // Note: 
+            // Note:
             // This behavior seems to be a macOS thing. In the Photino.Native
             // project files it is commented to be expected behavior for macOS.
             // There is some code trying to mitigate this problem but it might
@@ -1133,14 +1133,22 @@ namespace PhotinoNET
             return this;
         }
 
+        /// <summary> Set runtime path for WebView2 so that developers can use Photino on Windows using the "Fixed Version" deployment module of the WebView2 runtime. See https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution </summary>
+        public PhotinoWindow Win32SetWebView2Path (string data) {
+            if (IsWindowsPlatform)
+                Invoke(() => Photino_setWebView2RuntimePath_win32(_nativeType, data));
+            else
+                Log("Win32SetWebView2Path is only supported on the Windows platform");
 
+            return this;
+        }
 
 
 
         //NON-FLUENT METHODS - CAN ONLY BE CALLED AFTER WINDOW IS INITIALIZED
 
         //ONE OF THESE 2 METHODS *MUST* BE CALLED TO CREATE THE WINDOW
-        
+
         ///<summary>Initializes the main (first) native window and blocks until the window is closed. Also used to initialize child windows in which case it does not block. Only the main native window runs a message loop.</summary>
         public void WaitForClose()
         {
@@ -1155,8 +1163,8 @@ namespace PhotinoNET
                 i++;
             }
 
-            _startupParameters.NativeParent = _dotNetParent == null 
-                ? IntPtr.Zero 
+            _startupParameters.NativeParent = _dotNetParent == null
+                ? IntPtr.Zero
                 : _dotNetParent._nativeInstance;
 
             var errors = _startupParameters.GetParamErrors();


### PR DESCRIPTION
This is the companion to PR 74 (https://github.com/tryphotino/photino.Native/pull/74) in Photino.Native and exposes setting the WebView2 path from the managed code side of things.

I know the desire is to maintain a single interface for all platforms, but since WebView2 is the windows-only rendering backend I wasn't sure how we'd like to handle that. I noticed that the existing code does a lot of runtime platform checking, so I opted for a Win32 prefixed function with runtime checks, but other options could be...

1) Keep the Win32 prefixed function but compile it out on other platforms with #ifdefs. The project doesn't seem to favor this approach, so I avoided it so far.
2) Add an opaque object pointer field onto PhotinoNativeParameters and the corresponding Native struct which platforms could use to pass a platform-specific struct with platform-specific initialization information. (the WebView2 path in the case of Windows).
3) Add a new `SetInitData(o object)` function or something similar to inject platform-specific initialization data in a consistent but opaque way.
4) Another option I haven't thought of yet?

Marshaling opaque objects around seemed counter to the otherwise safe and easy-to-use API, so I ultimately opted for this implementation, but I'm open to whatever.