### PR TITLE
add `net7.0` TFM and allow for .NET 7 AOT

### DIFF
--- a/Photino.NET/Photino.NET.csproj
+++ b/Photino.NET/Photino.NET.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <Authors>TryPhotino</Authors>
     <Company>TryPhotino</Company>
-    <Description>.NET 6 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</Description>
+    <Description>.NET 6/7 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</Description>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);SetPackageVersion</GenerateNuspecDependsOn>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <PackageDescription>.NET 6 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</PackageDescription>
+    <PackageDescription>.NET 6/7 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</PackageDescription>
     <PackageId>Photino.NET</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Product>Photino.NET</Product>
@@ -18,7 +18,7 @@
   
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable> 
   </PropertyGroup>
 

--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -813,7 +813,12 @@ public partial class PhotinoWindow
         //This only has to be done once
         if (_nativeType == IntPtr.Zero)
         {
+#if NET7_0_OR_GREATER
+            _nativeType = NativeLibrary.GetMainProgramHandle();
+#else
             _nativeType = Marshal.GetHINSTANCE(typeof(PhotinoWindow).Module);
+#endif
+
             if (IsWindowsPlatform)
                 Invoke(() => Photino_register_win32(_nativeType));
             else if (IsMacOsPlatform)

--- a/azure-pipelines-photino.net-dev.yml
+++ b/azure-pipelines-photino.net-dev.yml
@@ -18,10 +18,17 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
+      displayName: 'Use .NET 6 sdk'
       inputs:
         packageType: sdk
         version: 6.0.x
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 7 sdk'
+      inputs:
+        packageType: sdk
+        version: 7.0.x
         installationPath: $(Agent.ToolsDirectory)/dotnet
 
     - task: CmdLine@2

--- a/azure-pipelines-photino.net-dev.yml
+++ b/azure-pipelines-photino.net-dev.yml
@@ -18,13 +18,6 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET 6 sdk'
-      inputs:
-        packageType: sdk
-        version: 6.0.x
-        installationPath: $(Agent.ToolsDirectory)/dotnet
-
-    - task: UseDotNet@2
       displayName: 'Use .NET 7 sdk'
       inputs:
         packageType: sdk

--- a/azure-pipelines-photino.net-prod.yml
+++ b/azure-pipelines-photino.net-prod.yml
@@ -18,13 +18,6 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET 6 sdk'
-      inputs:
-        packageType: sdk
-        version: 6.0.x
-        installationPath: $(Agent.ToolsDirectory)/dotnet
-
-    - task: UseDotNet@2
       displayName: 'Use .NET 7 sdk'
       inputs:
         packageType: sdk

--- a/azure-pipelines-photino.net-prod.yml
+++ b/azure-pipelines-photino.net-prod.yml
@@ -18,10 +18,17 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
+      displayName: 'Use .NET 6 sdk'
       inputs:
         packageType: sdk
         version: 6.0.x
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 7 sdk'
+      inputs:
+        packageType: sdk
+        version: 7.0.x
         installationPath: $(Agent.ToolsDirectory)/dotnet
 
     #Build and Create NuGet package


### PR DESCRIPTION
The method `Marshal.GetHINSTANCE()` is [not supported](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility) in AOT scenarios, but the method `NativeLibrary.GetMainProgramHandle()` was added in [.NET 7](https://github.com/dotnet/runtime/issues/63714#issuecomment-1011675863) and allows for this to work.

Since there's not a corresponding API to make this work in .NET 6, I multi-targeted the project so existing scenarios for .NET 6 users will still work.

Verified that .NET 7 AOT works on `win-x64`, `win-arm64`, and `linux-x64`; I don't have the hardware to check anything else.