### PR TITLE
Implementing basic menu support.

### DIFF
--- a/Photino.NET.Tests/MenuItemTests.cs
+++ b/Photino.NET.Tests/MenuItemTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Photino.NET.Tests;
+
+[TestFixture]
+[Platform("win")]
+public sealed class MenuItemTests
+{
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public void Add_ShouldThrow_WhenMenuItemHasParent()
+    {
+        // Arrange
+
+        using var menuItem1 = new MenuItem(new MenuItemOptions { Label = "Item 1" });
+        using var menuItem2 = new MenuItem(new MenuItemOptions { Label = "Item 2" });
+        using var menuItem3 = new MenuItem(new MenuItemOptions { Label = "Item 3" });
+        menuItem1.Add(menuItem3);
+
+        // Act
+
+        var act = () =>
+        {
+            menuItem2.Add(menuItem3);
+        };
+
+        // Assert
+
+        act.Should().Throw<Exception>();
+    }
+
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public void Add_ShouldThrow_WhenMenuItemIsSelf()
+    {
+        // Arrange
+
+        using var menuItem = new MenuItem(new MenuItemOptions { Label = "Item 1" });
+
+        // Act
+
+        var act = () =>
+        {
+            menuItem.Add(menuItem);
+        };
+
+        // Assert
+
+        act.Should().Throw<Exception>();
+    }
+
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public void Add_ShouldThrow_WhenMenuSeparatorHasParent()
+    {
+        // Arrange
+
+        var window = new PhotinoWindow();
+        using var menu = new Menu(window);
+        using var menuItem = new MenuItem(new MenuItemOptions { Label = "Item 1" });
+        using var menuSeparator = new MenuSeparator();
+        menu.Add(menuSeparator);
+
+        // Act
+
+        var act = () =>
+        {
+            menuItem.Add(menuSeparator);
+        };
+
+        // Assert
+
+        act.Should().Throw<Exception>();
+    }
+
+    [Test]
+    public void MenuItem_ShouldInitialize_WhenImageIsNull()
+    {
+        // Act & Assert
+
+        _ = new MenuItem(new MenuItemOptions { Label = "Item 1" });
+    }
+
+    [Test]
+    public void MenuItem_ShouldInitialize_WhenLabelIsNull()
+    {
+        // Act & Assert
+
+        _ = new MenuItem(new MenuItemOptions());
+    }
+}

--- a/Photino.NET.Tests/MenuTests.cs
+++ b/Photino.NET.Tests/MenuTests.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Photino.NET.Tests;
+
+[TestFixture]
+[Platform("win")]
+public sealed class MenuTests
+{
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public void Add_ShouldThrow_WhenMenuItemHasParent()
+    {
+        // Arrange
+
+        var window = new PhotinoWindow();
+        using var menu1 = new Menu(window);
+        using var menu2 = new Menu(window);
+        using var menuItem = new MenuItem(new MenuItemOptions { Label = "Item 1" });
+        menu1.Add(menuItem);
+
+        // Act
+
+        var act = () =>
+        {
+            menu2.Add(menuItem);
+        };
+
+        // Assert
+
+        act.Should().Throw<Exception>();
+    }
+
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public void Add_ShouldThrow_WhenMenuSeparatorHasParent()
+    {
+        // Arrange
+
+        var window = new PhotinoWindow();
+        using var menu1 = new Menu(window);
+        using var menu2 = new Menu(window);
+        using var menuSeparator = new MenuSeparator();
+        menu1.Add(menuSeparator);
+
+        // Act
+
+        var act = () =>
+        {
+            menu2.Add(menuSeparator);
+        };
+
+        // Assert
+
+        act.Should().Throw<Exception>();
+    }
+
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public void Dispose_ShouldDisposeAllDescendants()
+    {
+        // Arrange
+
+        var window = new PhotinoWindow();
+        var menu = new Menu(window);
+
+        MenuItem[] menuItems =
+        [
+            new MenuItem(new MenuItemOptions { Label = "Item 1" }),
+            new MenuItem(new MenuItemOptions { Label = "Item 2" }),
+            new MenuItem(new MenuItemOptions { Label = "Item 3" }),
+            new MenuItem(new MenuItemOptions { Label = "Item 4" })
+        ];
+
+        menu.Add(menuItems[0]);
+        menu.Add(menuItems[1]);
+        menuItems[1].Add(menuItems[2]);
+        menuItems[1].Add(menuItems[3]);
+
+        // Act
+
+        menu.Dispose();
+
+        // Assert
+
+        using var undisposedMenuItem = new MenuItem(new MenuItemOptions { Label = "Item 5" });
+
+        foreach (var menuItem in menuItems)
+        {
+            var add = () =>
+            {
+                menuItem.Add(undisposedMenuItem);
+            };
+
+            add.Should().Throw<ObjectDisposedException>();
+        }
+    }
+
+    [Test]
+    [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
+    public async Task Show_ShouldThrow_WhenPhotinoHasNotInitialized()
+    {
+        // Arrange
+
+        var window = new PhotinoWindow();
+        using var menu = new Menu(window);
+
+        // Act
+
+        var act = async () =>
+        {
+            await menu.Show(0, 0);
+        };
+
+        // Assert
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/Photino.NET.Tests/Photino.NET.Tests.csproj
+++ b/Photino.NET.Tests/Photino.NET.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Photino.NET\Photino.NET.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Photino.NET.sln
+++ b/Photino.NET.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photino.NET.Tests", "Photino.NET.Tests\Photino.NET.Tests.csproj", "{0287EFF1-DF1F-409D-B0F3-6239B8A2AE5A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{BB5C5BF0-D891-4005-BEC2-A654FCF02D5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB5C5BF0-D891-4005-BEC2-A654FCF02D5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB5C5BF0-D891-4005-BEC2-A654FCF02D5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0287EFF1-DF1F-409D-B0F3-6239B8A2AE5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0287EFF1-DF1F-409D-B0F3-6239B8A2AE5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0287EFF1-DF1F-409D-B0F3-6239B8A2AE5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0287EFF1-DF1F-409D-B0F3-6239B8A2AE5A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Photino.NET/Menu.cs
+++ b/Photino.NET/Menu.cs
@@ -1,0 +1,236 @@
+﻿using System.Collections;
+
+namespace Photino.NET;
+
+public sealed class Menu : MenuNode, IEnumerable<MenuNode>
+{
+    private readonly List<MenuNode> _children = [];
+    private IntPtr _handle;
+    private readonly PhotinoWindow _window;
+
+    /// <summary>
+    /// Initializes a new <see cref="Menu"/>.
+    /// </summary>
+    /// <param name="window">The parent window of this menu.</param>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public Menu(PhotinoWindow window)
+    {
+        _window = window;
+        PhotinoWindow.Photino_Menu_Create(out _handle).ThrowOnFailure();
+    }
+
+    ~Menu()
+    {
+        Dispose(false);
+    }
+
+    /// <summary>
+    /// Adds a menu item to the menu.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <exception cref="ObjectDisposedException">The menu or the item has been disposed.</exception>
+    /// <exception cref="ArgumentException">The item already has a parent.</exception>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public void Add(MenuItem item)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(Menu));
+        }
+
+        if (item._handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(MenuItem));
+        }
+
+        if (item.Parent != null)
+        {
+            throw new ArgumentException("Cannot add the same item to multiple menus.", nameof(item));
+        }
+
+        PhotinoWindow.Photino_Menu_AddMenuItem(_handle, item._handle).ThrowOnFailure();
+        _children.Add(item);
+        item.Parent = this;
+    }
+
+    /// <summary>
+    /// Adds a separator to the menu.
+    /// </summary>
+    /// <param name="separator">The separator to add.</param>
+    /// <exception cref="ObjectDisposedException">The menu or the separator has been disposed.</exception>
+    /// <exception cref="ArgumentException">The separator already has a parent.</exception>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public void Add(MenuSeparator separator)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(Menu));
+        }
+
+        if (separator._handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(MenuSeparator));
+        }
+
+        if (separator.Parent != null)
+        {
+            throw new ArgumentException("Cannot add the same separator to multiple menus.", nameof(separator));
+        }
+
+        PhotinoWindow.Photino_Menu_AddMenuSeparator(_handle, separator._handle).ThrowOnFailure();
+        _children.Add(separator);
+        separator.Parent = this;
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<MenuNode> GetEnumerator()
+    {
+        return _children.GetEnumerator();
+    }
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Dismisses the menu.
+    /// </summary>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public void Hide()
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(Menu));
+        }
+
+        PhotinoWindow.Photino_Menu_Hide(_handle).ThrowOnFailure();
+    }
+
+    /// <summary>
+    /// Displays the menu.
+    /// </summary>
+    /// <param name="x">The x-coordinate of the top-left corner of the menu, relative to the associated window.</param>
+    /// <param name="y">The y-coordinate of the top-right corner of the menu, relative to the associated window.</param>
+    /// <returns>The selected item on completion, or null if the menu was dismissed without a selection.</returns>
+    /// <exception cref="InvalidOperationException">The associated window is not initialized.</exception>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public async Task<MenuItem> Show(int x, int y)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(Menu));
+        }
+
+        if (_window._nativeInstance == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("The associated window is not initialized.");
+        }
+
+        var tcs = new TaskCompletionSource<MenuItem>();
+        PhotinoWindow.Photino_Menu_AddOnClicked(_handle, OnClicked).ThrowOnFailure();
+
+        try
+        {
+            PhotinoWindow.Photino_Menu_Show(_handle, _window._nativeInstance, x, y).ThrowOnFailure();
+            return await tcs.Task;
+        }
+        finally
+        {
+            if (PhotinoWindow.Photino_Menu_RemoveOnClicked(_handle, OnClicked) != PhotinoErrorKind.NoError)
+            {
+                // TODO: Log this error.
+            }
+        }
+
+        void OnClicked(IntPtr selectedMenuItemHandle)
+        {
+            if (selectedMenuItemHandle == IntPtr.Zero)
+            {
+                tcs.SetResult(null);
+            }
+            else
+            {
+                tcs.SetResult(FindItemWithHandle(selectedMenuItemHandle));
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    internal override void ClearHandles()
+    {
+        _handle = IntPtr.Zero;
+
+        for (var i = 0; i < _children.Count; ++i)
+        {
+            _children[i].ClearHandles();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        // Destroying the menu destroys its children, so we update our handles to reflect their actual states.
+        PhotinoWindow.Photino_Menu_Destroy(_handle);
+        _handle = IntPtr.Zero;
+        ClearHandles();
+    }
+
+    /// <summary>
+    /// Searches descendants of this menu for an item with the given handle.
+    /// </summary>
+    /// <param name="handle">The handle.</param>
+    /// <returns>The menu item with the given handle, or null if one doesn't exist.</returns>
+    private MenuItem FindItemWithHandle(IntPtr handle)
+    {
+        for (var i = 0; i < _children.Count; ++i)
+        {
+            if (_children[i] is MenuItem menuItem)
+            {
+                var result = FindItemWithHandle(menuItem, handle);
+
+                if (result != null)
+                {
+                    return result;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Searches the given menu item and its descendants for an item with the given handle.
+    /// </summary>
+    /// <param name="root">The menu item.</param>
+    /// <param name="handle">The handle.</param>
+    /// <returns>The menu item with the given handle, or null if one doesn't exist.</returns>
+    private static MenuItem FindItemWithHandle(MenuItem root, IntPtr handle)
+    {
+        if (root._handle == handle)
+        {
+            return root;
+        }
+
+        foreach (var child in root)
+        {
+            if (child is MenuItem childMenuItem)
+            {
+                var result = FindItemWithHandle(childMenuItem, handle);
+
+                if (result != null)
+                {
+                    return result;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/Photino.NET/MenuItem.cs
+++ b/Photino.NET/MenuItem.cs
@@ -1,0 +1,137 @@
+﻿using System.Collections;
+
+namespace Photino.NET;
+
+public sealed class MenuItem : MenuNode, IEnumerable<object>
+{
+    private readonly List<MenuNode> _children = [];
+    internal IntPtr _handle;
+
+    /// <summary>
+    /// The user-defined identifier. Each item within a menu should have a unique identifier.
+    /// </summary>
+    public int Id { get; }
+
+    /// <summary>
+    /// The text displayed to the user.
+    /// </summary>
+    public string Label { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="MenuItem"/>.
+    /// </summary>
+    /// <param name="options">Options specifying the behavior.</param>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public MenuItem(MenuItemOptions options)
+    {
+        Id = options.Id;
+        Label = options.Label;
+
+        var nativeOptions = new NativeMenuItemOptions
+        {
+            Label = options.Label
+        };
+
+        PhotinoWindow.Photino_MenuItem_Create(nativeOptions, out _handle).ThrowOnFailure();
+    }
+
+    ~MenuItem()
+    {
+        Dispose(false);
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<object> GetEnumerator()
+    {
+        return _children.GetEnumerator();
+    }
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Adds a menu item to this item's submenu.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <exception cref="ArgumentException">Tried to add an item to itself or the item already has a parent.</exception>
+    /// <exception cref="ObjectDisposedException">This item or the item to be added has been disposed.</exception>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public void Add(MenuItem item)
+    {
+        if (_handle == IntPtr.Zero || item._handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(MenuItem));
+        }
+
+        if (item == this)
+        {
+            throw new ArgumentException("Cannot add an item to itself.", nameof(item));
+        }
+
+        if (item.Parent != null)
+        {
+            throw new ArgumentException("Cannot add the same item to multiple menus.", nameof(item));
+        }
+
+        _children.Add(item);
+        item.Parent = this;
+        PhotinoWindow.Photino_MenuItem_AddMenuItem(_handle, item._handle).ThrowOnFailure();
+    }
+
+    /// <summary>
+    /// Adds a separator to this item's submenu.
+    /// </summary>
+    /// <param name="separator">The separator to add.</param>
+    /// <exception cref="ObjectDisposedException">This item or the separator to be added has been disposed.</exception>
+    /// <exception cref="ArgumentException">The separator already has a parent.</exception>
+    public void Add(MenuSeparator separator)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(MenuItem));
+        }
+
+        if (separator._handle == IntPtr.Zero)
+        {
+            throw new ObjectDisposedException(nameof(MenuSeparator));
+        }
+
+        if (separator.Parent != null)
+        {
+            throw new ArgumentException("Cannot add the same separator to multiple menus.", nameof(separator));
+        }
+
+        _children.Add(separator);
+        separator.Parent = this;
+        PhotinoWindow.Photino_MenuItem_AddMenuSeparator(_handle, separator._handle).ThrowOnFailure();
+    }
+
+    /// <inheritdoc />
+    internal override void ClearHandles()
+    {
+        _handle = IntPtr.Zero;
+        Parent = null;
+
+        for (var i = 0; i < _children.Count; ++i)
+        {
+            _children[i].ClearHandles();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        // TODO: Remove from `Parent`.
+        PhotinoWindow.Photino_MenuItem_Destroy(_handle); // Don't throw in finalizer.
+        _handle = IntPtr.Zero;
+        Parent = null;
+    }
+}

--- a/Photino.NET/MenuItemOptions.cs
+++ b/Photino.NET/MenuItemOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Photino.NET;
+
+public sealed class MenuItemOptions
+{
+    /// <summary>
+    /// The user-specified id.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The text displayed to the user.
+    /// </summary>
+    public string Label { get; set; }
+}

--- a/Photino.NET/MenuNode.cs
+++ b/Photino.NET/MenuNode.cs
@@ -1,0 +1,28 @@
+﻿namespace Photino.NET;
+
+public abstract class MenuNode : IDisposable
+{
+    public MenuNode Parent { get; internal set; }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        Dispose(true);
+    }
+
+    /// <summary>
+    /// Clears the handles of all descendants.
+    /// </summary>
+    internal virtual void ClearHandles()
+    {
+    }
+
+    /// <summary>
+    /// Disposes resources.
+    /// </summary>
+    /// <param name="disposing">Whether we are called from <see cref="IDisposable.Dispose"/>.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+    }
+}

--- a/Photino.NET/MenuSeparator.cs
+++ b/Photino.NET/MenuSeparator.cs
@@ -1,0 +1,44 @@
+﻿namespace Photino.NET;
+
+public sealed class MenuSeparator : MenuNode
+{
+    internal IntPtr _handle;
+
+    /// <summary>
+    /// Initializes a new <see cref="MenuSeparator" />.
+    /// </summary>
+    /// <exception cref="PhotinoNativeException">A platform specific call failed.</exception>
+    public MenuSeparator()
+    {
+        PhotinoWindow.Photino_MenuSeparator_Create(out _handle).ThrowOnFailure();
+    }
+
+    /// <summary>
+    /// Finalizer.
+    /// </summary>
+    ~MenuSeparator()
+    {
+        Dispose(false);
+    }
+
+    /// <inheritdoc />
+    internal override void ClearHandles()
+    {
+        _handle = IntPtr.Zero;
+        Parent = null;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (_handle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        // TODO: Remove from `Parent`.
+        PhotinoWindow.Photino_MenuSeparator_Destroy(_handle);
+        _handle = IntPtr.Zero;
+        Parent = null;
+    }
+}

--- a/Photino.NET/NativeMenuItemOptions.cs
+++ b/Photino.NET/NativeMenuItemOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace Photino.NET;
+
+/// <summary>
+/// Interop struct.
+/// </summary>
+public struct NativeMenuItemOptions
+{
+    public string Label;
+}

--- a/Photino.NET/Photino.NET.csproj
+++ b/Photino.NET/Photino.NET.csproj
@@ -24,6 +24,10 @@
 		<IsPackable>true</IsPackable>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
+
+	<PropertyGroup>
+		<PhotinoNativeVersion Condition=" '$(PhotinoNativeVersion)' == '' ">3.2.3</PhotinoNativeVersion>
+	</PropertyGroup>
 	
 	<Target Name="SetPackageVersion" DependsOnTargets="Build">
 		<PropertyGroup>
@@ -32,7 +36,7 @@
 	</Target>
 
   <ItemGroup>
-    <PackageReference Include="Photino.Native" Version="3.2.3" />
+    <PackageReference Include="Photino.Native" Version="$(PhotinoNativeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Photino.NET/PhotinoDllImports.cs
+++ b/Photino.NET/PhotinoDllImports.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Photino.NET;
 
@@ -353,4 +354,55 @@ public partial class PhotinoWindow
     [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true, CharSet = CharSet.Ansi)]
     public static extern PhotinoDialogResult Photino_ShowMessage(IntPtr inst, [MarshalAs(UnmanagedType.LPUTF8Str)] string title, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, PhotinoDialogButtons buttons, PhotinoDialogIcon icon);
 #endif
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Photino_ClearErrorMessage();
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Photino_GetErrorMessage(int length, byte[] buffer);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Photino_GetErrorMessageLength(out int length);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_Create(out IntPtr menu);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_Destroy(IntPtr menu);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_AddMenuItem(IntPtr menu, IntPtr menuItem);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_AddMenuSeparator(IntPtr menu, IntPtr menuSeparator);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_AddOnClicked(IntPtr menu, MenuOnClicked onClicked);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_Hide(IntPtr menu);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_RemoveOnClicked(IntPtr menu, MenuOnClicked onClicked);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_Menu_Show(IntPtr menu, IntPtr window, int x, int y);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_MenuItem_Create(NativeMenuItemOptions options, out IntPtr menuItem);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_MenuItem_Destroy(IntPtr menuItem);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_MenuItem_AddMenuItem(IntPtr menuItem, IntPtr newMenuItem);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_MenuItem_AddMenuSeparator(IntPtr menuItem, IntPtr menuSeparator);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_MenuSeparator_Create(out IntPtr menuSeparator);
+
+    [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+    public static extern PhotinoErrorKind Photino_MenuSeparator_Destroy(IntPtr menuSeparator);
 }

--- a/Photino.NET/PhotinoErrorKind.cs
+++ b/Photino.NET/PhotinoErrorKind.cs
@@ -1,0 +1,10 @@
+﻿namespace Photino.NET;
+
+/// <summary>
+/// The error kind from Photino.Native functions.
+/// </summary>
+public enum PhotinoErrorKind
+{
+    NoError = 0,
+    GenericError
+}

--- a/Photino.NET/PhotinoErrorKindExtensions.cs
+++ b/Photino.NET/PhotinoErrorKindExtensions.cs
@@ -1,0 +1,22 @@
+namespace Photino.NET;
+
+/// <summary>
+/// Extensions for <see cref="PhotinoErrorKind"/>.
+/// </summary>
+public static class PhotinoErrorKindExtensions
+{
+    /// <summary>
+    /// Throws a <see cref="PhotinoNativeException"/> if <see cref="errorKind"/> represents an unsuccessful result.
+    /// </summary>
+    /// <param name="errorKind">The error kind.</param>
+    /// <exception cref="PhotinoNativeException">
+    /// <see cref="errorKind"/> is an unsuccessful result.
+    /// </exception>
+    public static void ThrowOnFailure(this PhotinoErrorKind errorKind)
+    {
+        if (errorKind != PhotinoErrorKind.NoError)
+        {
+            throw new PhotinoNativeException();
+        }
+    }
+}

--- a/Photino.NET/PhotinoException.cs
+++ b/Photino.NET/PhotinoException.cs
@@ -1,0 +1,22 @@
+﻿namespace Photino.NET;
+
+/// <summary>
+/// The base exception class for Photino.NET.
+/// </summary>
+public class PhotinoException : Exception
+{
+    /// <inheritdoc cref="Exception()"/>
+    public PhotinoException()
+    {
+    }
+
+    /// <inheritdoc cref="Exception(string)"/>
+    public PhotinoException(string message) : base(message)
+    {
+    }
+
+    /// <inheritdoc cref="Exception(string, Exception)"/>
+    public PhotinoException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/Photino.NET/PhotinoNativeDelegates.cs
+++ b/Photino.NET/PhotinoNativeDelegates.cs
@@ -19,3 +19,6 @@ namespace Photino.NET;
 //These are sent in during the request
 [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate int CppGetAllMonitorsDelegate(in NativeMonitor monitor);
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)] delegate void InvokeCallback();
+
+//Menu
+[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate void MenuOnClicked(IntPtr menuItemHandle);

--- a/Photino.NET/PhotinoNativeException.cs
+++ b/Photino.NET/PhotinoNativeException.cs
@@ -1,0 +1,28 @@
+﻿using System.Text;
+
+namespace Photino.NET;
+
+public sealed class PhotinoNativeException : PhotinoException // TODO: Consider calling this `NativePhotinoException`.
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="PhotinoNativeException"/>, using the most recent error message created
+    /// by Photino.Native on this thread.
+    /// </summary>
+    public PhotinoNativeException() : base(GetErrorMessage())
+    {
+    }
+
+    /// <summary>
+    /// Gets the most recent native error message if there is one.
+    /// </summary>
+    /// <returns>The most recent native error message.</returns>
+    private static string GetErrorMessage()
+    {
+        PhotinoWindow.Photino_GetErrorMessageLength(out var length);
+        var buffer = new byte[length];
+        PhotinoWindow.Photino_GetErrorMessage(length, buffer);
+        var result = Encoding.UTF8.GetString(buffer);
+        PhotinoWindow.Photino_ClearErrorMessage();
+        return result;
+    }
+}

--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 namespace Photino.NET;
@@ -49,7 +50,7 @@ public partial class PhotinoWindow
 
     //Pointers to the type and instance.
     private static IntPtr _nativeType = IntPtr.Zero;
-    private IntPtr _nativeInstance;
+    internal IntPtr _nativeInstance;
     private readonly int _managedThreadId;
 
     //There can only be 1 message loop for all windows.


### PR DESCRIPTION
## What does the pull request do?

This pull request adds support for menus on the Windows platform via win32 APIs.

![win32_menus](https://github.com/user-attachments/assets/f2ef9ad7-754b-4b3e-a85e-7365a980e1db)
![linux_menus](https://github.com/user-attachments/assets/84cf0aab-1079-4b9b-956f-9ae2ff745055)
![mac_menus](https://github.com/user-attachments/assets/de1d4e14-847c-4f08-878c-6acdf124e993)


## What is the current behavior?

Currently, there is no support for native menus.

## What is the expected behavior?

There should be support for native menus.

## How was the solution implemented?

Care was taken to inspect [GtkMenu](https://docs.gtk.org/gtk3/class.Menu.html) and [NSMenu](https://developer.apple.com/documentation/appkit/nsmenu) when designing this API. The basic `Menu`, `MenuItem`, and `MenuSeparator` classes can easily be translated into relevant types and calls for both AppKit and GTK. This rudimentary API (i.e., no checkboxes, no enabled / disabled states, etc.) should be straightforward to implement for the other platforms.

## Fixed issues

#43 

## Remarks

@philippjbauer @MikeYeager 