### PR TITLE
Add overload to SetIconFile for loading icon from embedded resource

### DIFF
--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Photino.NET;
@@ -1994,6 +1995,7 @@ public partial class PhotinoWindow
         Height = height;
         return this;
     }
+
     /// <summary>
     /// Sets the icon file for the native window title bar.
     /// The file must be located on the local machine and cannot be a URL. The default is none.
@@ -2011,6 +2013,28 @@ public partial class PhotinoWindow
         Log($".SetIconFile({iconFile})");
         IconFile = iconFile;
         return this;
+    }
+
+    /// <summary>
+    /// Sets the icon file for the native window title bar from an embedded resource.
+    /// The resource file is extracted to a temporary file, and its path is then set as the icon.
+    /// </summary>
+    /// <remarks>
+    /// This only works on Windows and Linux.
+    /// The resource file is expected to be embedded in the assembly from the `wwwroot` folder, and the provided namespace is used to locate the resource.
+    /// </remarks>
+    /// <returns>
+    /// Returns the current <see cref="PhotinoWindow"/> instance.
+    /// </returns>
+    /// <param name="resourceFileName">The name of the embedded resource file (e.g., "favicon.ico").</param>
+    /// <param name="resourceNamespace">
+    /// The namespace in which the embedded resource is located (e.g., "MyApp" or "MyCompany.MyApp").
+    /// This allows for specifying the custom namespace where the resource is embedded.
+    /// </param>
+    public PhotinoWindow SetIconFile(string resourceFileName, string resourceNamespace)
+    {
+        string iconPath = ExtractEmbeddedResourceToTempFile(resourceFileName, resourceNamespace);
+        return iconPath != null ? SetIconFile(iconPath) : this;
     }
 
     /// <summary>
@@ -2695,5 +2719,44 @@ public partial class PhotinoWindow
         return nativeFilters;
     }
 
+    /// <summary>
+    /// Extracts an embedded resource from the assembly to a temporary file.
+    /// </summary>
+    /// <remarks>
+    /// The resource is expected to be located within the provided namespace and under the `wwwroot` folder.
+    /// This method will write the resource to a temporary file and return its path.
+    /// </remarks>
+    /// <returns>
+    /// The path to the temporary file containing the extracted resource, or <c>null</c> if the resource was not found.
+    /// </returns>
+    /// <param name="fileName">The name of the embedded resource file (e.g., "favicon.ico").</param>
+    /// <param name="resourceNamespace">
+    /// The namespace where the embedded resource is located (e.g., "MyApp" or "MyCompany.MyApp").
+    ///
+    /// The method expects the resource to be in the `wwwroot` folder of the provided namespace.
+    /// </param>
+    private string ExtractEmbeddedResourceToTempFile(string fileName, string resourceNamespace)
+    {
+        string resourceName = $"{resourceNamespace}.wwwroot.{fileName}";
 
+        Assembly assembly = Assembly.GetExecutingAssembly();
+
+        using (Stream resourceStream = assembly.GetManifestResourceStream(resourceName))
+        {
+            if (resourceStream == null)
+            {
+                Log($"Resource '{fileName}' couldn't be found in namespace '{resourceNamespace}'");
+                return null;
+            }
+
+            string tempFile = Path.Combine(Path.GetTempPath(), fileName);
+
+            using (FileStream fileStream = new FileStream(tempFile, FileMode.Create, FileAccess.Write))
+            {
+                resourceStream.CopyTo(fileStream);
+            }
+
+            return tempFile;
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## <span>NEXT PHOTINO FEATURES POLL</span>
-Hello Photino Community! Please take a moment to check out our Photino poll and vote on the next features to be implemented, here:
+## <span>NEW POLL!!</span>
+Hello Photino Community! We have a new poll question, regarding where and how you use Photino:
 
-[PHOTINO POLL](https://github.com/tryphotino/photino.NET/discussions/117)
+[PHOTINO USAGE POLL](https://github.com/tryphotino/photino.NET/discussions/172)
 
 
 # Build native, cross-platform desktop apps


### PR DESCRIPTION
This PR introduces an enhancement to the `PhotinoWindow.SetIconFile()` method to allow it to accept embedded resources directly, improving the integration with projects like `Photino.Blazor`.

### Key Changes:
- Added a new overloaded version of `SetIconFile()` that allows the user to specify an embedded resource along with its namespace, removing the need to manually extract the resource to a temporary file.
- Introduced a utility method, `ExtractEmbeddedResourceToTempFile()`, which facilitates the extraction of embedded resources from the assembly and saves them to a temporary file for use as the window icon.
- Updated the method to support the seamless integration of `SetIconFile()` with embedded resources, addressing issues where `SetIconFile()` previously required physical paths and couldn't handle virtual paths provided by `ManifestEmbeddedFileProvider`.

### Related Issue:
This addresses an issue in the Photino.Blazor project where attempting to set a favicon from an embedded resource caused the application to fail at launch. The new functionality allows the `SetIconFile()` method to work smoothly with resources embedded in the assembly.

The issue is being discussed in tryphotino/photino.Blazor#147

### Motivation:
By enabling `SetIconFile()` to accept embedded resources directly, we simplify the process of setting the icon for applications that are fully self-contained and do not require manual extraction of resources to physical paths. This change also aligns with the Photino.Blazor project, where embedding static resources like MudBlazor into the executable while ensuring the app remains fully self-contained are supported.

### Next Steps:

- I have opened a separate PR for Photino.Blazor tryphotino/photino.Blazor/pull/154 with a sample project and a README detailing how to embed static resources in a fully self-contained executable
- I will work on a follow-up PR if this current one gets merged to update the sample project with the simplified usage of the overloaded `SetIcon()` method.