### PR TITLE
feat: add docs symbols to nuget package

### DIFF
--- a/Photino.NET/Photino.NET.csproj
+++ b/Photino.NET/Photino.NET.csproj
@@ -15,6 +15,14 @@
 		<Title>Photino.NET</Title>
 		<RootNamespace>Photino.NET</RootNamespace>
 	</PropertyGroup>
+	
+	<!-- debug info, symbols -->
+	<PropertyGroup>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -25,15 +33,15 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Copyright>Copyright (C) 2025</Copyright>
 	</PropertyGroup>
-	
+
 	<Target Name="SetPackageVersion" DependsOnTargets="Build">
 		<PropertyGroup>
 			<PackageVersion>$(Version)</PackageVersion>
 		</PropertyGroup>
 	</Target>
 
-  <ItemGroup>
-    <PackageReference Include="Photino.Native" Version="4.0.22" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Photino.Native" Version="4.0.22" />
+	</ItemGroup>
 
 </Project>

--- a/azure-pipelines-photino.net-dev.yml
+++ b/azure-pipelines-photino.net-dev.yml
@@ -45,7 +45,7 @@ jobs:
                 command: push
                 feedsToUse: "select"
                 publishVstsFeed: "Photino.Native/PhotinoPackages"
-                packagesToPush: "Photino.NET/bin/$(buildConfiguration)/*.nupkg"
+                packagesToPush: "Photino.NET/bin/$(buildConfiguration)/*.symbols.nupkg"
                 allowPackageConflicts: true
 
     # Uploads the NuGet package file to nuget.org

--- a/azure-pipelines-photino.net-prod.yml
+++ b/azure-pipelines-photino.net-prod.yml
@@ -29,7 +29,7 @@ jobs:
             displayName: "Build and Create NuGet package"
             inputs:
                 script: "dotnet pack Photino.NET/Photino.NET.csproj -c $(buildConfiguration) /p:Version=$(major).$(minor).$(patch) /p:PackageVersion=$(major).$(minor).$(patch)"
-
+          
           # Uploads the NuGet package file to nuget.org
           # Important notes:
           # 1. For this to work, you need to create a 'service connection' with the same name
@@ -42,6 +42,6 @@ jobs:
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
                 command: push
-                packagesToPush: "Photino.NET/bin/$(buildConfiguration)/*.nupkg"
+                packagesToPush: "Photino.NET/bin/$(buildConfiguration)/*.symbols.nupkg"
                 nuGetFeedType: external
                 publishFeedCredentials: "PhotinoNetNuGet"


### PR DESCRIPTION
Right now, the [Photino.NET](https://www.nuget.org/packages/Photino.NET/) package does not include debugging symbols or documentation XML, making development more complicated when we cannot access the `<summary>` member documentation in the code.

This PR fixes this, making `dotnet pack` create a **.symbols.nupkg** file alongside the **.nupkg** file, and using this for package upload instead of the symbol-less package.