### PR TITLE
Allow parent window to be set before initialized

### DIFF
--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -865,7 +865,8 @@ public partial class PhotinoWindow
         }
     }
 
-    private readonly PhotinoWindow _dotNetParent;
+    private PhotinoWindow _dotNetParent;
+
     /// <summary>
     /// Gets the reference to parent PhotinoWindow instance.
     /// This property can only be set in the constructor and it is optional.
@@ -1741,6 +1742,23 @@ public partial class PhotinoWindow
             throw new ApplicationException("Chromeless can only be set before the native window is instantiated.");
 
         _startupParameters.Chromeless = chromeless;
+        return this;
+    }
+
+    /// <summary>
+    /// Set the parent window
+    /// </summary>
+    /// <returns>
+    /// Returns the current <see cref="PhotinoWindow"/> instance.
+    /// </returns>
+    /// <param name="parent">The window that should be used as this window's parent</param>
+    public PhotinoWindow SetParent(PhotinoWindow parent)
+    {
+        Log($".SetParent({parent.Id})");
+        if (_nativeInstance != IntPtr.Zero)
+            throw new ApplicationException("Parent window can only be set before the native window is instantiated.");
+
+        _dotNetParent = parent;
         return this;
     }
 


### PR DESCRIPTION
This PR adds the ability to set the parent window on a new window before it's instantiated. This allows applications built with [photino.Blazor](https://github.com/tryphotino/photino.Blazor) to have new windows with parents.

photino.Blazor utilizes dependency injection when creating new windows, so each window is effectively a separate Blazor app. This creates the undesired UI effect where one application can look like multiple. i.e. on Windows, multi-window Photino Blazor applications will not combine under one taskbar item.

A check was put in place to make sure that a native instance of the current window does not already exist. As the parent is used as a startup parameter, this mirrors checks put in for other pre-instantiated parameters such as chromeless.