### PR TITLE
feat(linux): Implement WindowHandle property using native GtkWindow pointer

### DIFF
--- a/Photino.NET/PhotinoDllImports.cs
+++ b/Photino.NET/PhotinoDllImports.cs
@@ -43,6 +43,10 @@ public partial class PhotinoWindow
 
     [LibraryImport(DLL_NAME, SetLastError = true)]
     [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial IntPtr Photino_getGtkWindow_linux(IntPtr instance);
+
+    [LibraryImport(DLL_NAME, SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     static partial void Photino_GetAllMonitors(IntPtr instance, CppGetAllMonitorsDelegate callback);
 
     [LibraryImport(DLL_NAME, SetLastError = true)]

--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -86,33 +86,36 @@ public partial class PhotinoWindow
     public static bool IsLinuxPlatform => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
     /// <summary>
-    /// Represents a property that gets the handle of the native window on a Windows platform. 
+    /// Represents a property that gets the pointer/handle to the underlying native window. 
+    /// On Windows, this returns a Win32 HWND. On Linux, this returns a GtkWindow pointer (GtkWidget*).
     /// </summary>
     /// <remarks>
-    /// Only available on the Windows platform. 
-    /// If this property is accessed from a non-Windows platform, a PlatformNotSupportedException will be thrown.
+    /// Currently supported on Windows and Linux platforms. 
+    /// If this property is accessed from an unsupported platform (e.g., macOS), a PlatformNotSupportedException will be thrown.
     /// If this property is accessed before the window is initialized, an ApplicationException will be thrown.
     /// </remarks>
     /// <value>
-    /// The handle of the native window. The value is of type <see cref="IntPtr"/>.
+    /// The native window handle or pointer. The value is of type <see cref="IntPtr"/>.
     /// </value>
     /// <exception cref="System.ApplicationException">Thrown when the window is not initialized yet.</exception>
-    /// <exception cref="System.PlatformNotSupportedException">Thrown when accessed from a non-Windows platform.</exception>
+    /// <exception cref="System.PlatformNotSupportedException">Thrown when accessed from an unsupported platform.</exception>
     public IntPtr WindowHandle
     {
         get
         {
-            if (IsWindowsPlatform)
-            {
-                if (_nativeInstance == IntPtr.Zero)
-                    throw new ApplicationException("The Photino window is not initialized yet");
+            if (_nativeInstance == IntPtr.Zero)
+                throw new ApplicationException("The Photino window is not initialized yet.");
+                
+            var handle = IntPtr.Zero;
 
-                var handle = IntPtr.Zero;
+            if (IsWindowsPlatform)
                 Invoke(() => handle = Photino_getHwnd_win32(_nativeInstance));
-                return handle;
-            }
+            else if (IsLinuxPlatform)
+                Invoke(() => handle = Photino_getGtkWindow_linux(_nativeInstance));
             else
-                throw new PlatformNotSupportedException($"{nameof(WindowHandle)} is only supported on Windows.");
+                throw new PlatformNotSupportedException($"{nameof(WindowHandle)} is only supported on Windows and Linux.");
+
+            return handle;
         }
     }
 


### PR DESCRIPTION
This PR implements the `WindowHandle` property for the Linux platform, resolving the `PlatformNotSupportedException` that was previously thrown. It properly invokes the newly exported `Photino_getGtkWindow_linux` native function to retrieve the underlying `GtkWidget*` pointer.

**⚠️ Dependency:**
This PR depends on the C++ export implemented in the Native repository. **Please merge this PR alongside or after:** `https://github.com/tryphotino/photino.Native/pull/178`

With this implementation, Linux developers can now access the underlying GTK window pointer directly from the framework. This is crucial for performing OS-specific window manipulations (like setting X11/Wayland specific window hints, custom GTK header bars, or advanced transparency effects) without having to rely on expensive workarounds like iterating over `gtk_window_list_toplevels()`.

- Added `Photino_getGtkWindow_linux` to `PhotinoDllImports.cs` via `[LibraryImport]`.
- Updated `WindowHandle` property in `PhotinoWindow.NET.cs` to correctly route the call on Linux platforms inside the UI thread.
- Updated XML documentation to clarify that the property returns a `HWND` on Windows and a `GtkWindow` pointer on Linux.

- Tested locally on Fedora Workstation using `.NET 9`.
- Verified that calling `WindowHandle` successfully retrieves the correct memory pointer for the GTK window without crashing or freezing the UI thread.