### PR TITLE
Add input dialog requested event

### DIFF
--- a/Photino.NET/InputDialogEventArgs.cs
+++ b/Photino.NET/InputDialogEventArgs.cs
@@ -1,5 +1,8 @@
 namespace Photino.NET;
 
+/// <summary>
+/// Provides data for a JavaScript alert dialog request.
+/// </summary>
 public class InputDialogEventArgs : EventArgs
 {
     internal InputDialogEventArgs(PhotinoWindow window, string message)
@@ -8,14 +11,26 @@ public class InputDialogEventArgs : EventArgs
         Message = message ?? string.Empty;
     }
 
+    /// <summary>
+    /// Gets the Photino window that requested the dialog.
+    /// </summary>
     public PhotinoWindow Window { get; }
 
+    /// <summary>
+    /// Gets the message displayed by the JavaScript dialog.
+    /// </summary>
     public string Message { get; }
 
+    /// <summary>
+    /// Gets whether the dialog request was handled by the event handler.
+    /// </summary>
     public bool Handled { get; private set; }
 
     internal bool Dismissed { get; private set; }
 
+    /// <summary>
+    /// Dismisses the requested dialog.
+    /// </summary>
     public void DismissDialog()
     {
         Handled = true;
@@ -29,6 +44,9 @@ public class InputDialogEventArgs : EventArgs
     }
 }
 
+/// <summary>
+/// Provides data for a JavaScript confirm dialog request.
+/// </summary>
 public sealed class ConfirmInputDialogEventArgs : InputDialogEventArgs
 {
     internal ConfirmInputDialogEventArgs(PhotinoWindow window, string message)
@@ -38,6 +56,10 @@ public sealed class ConfirmInputDialogEventArgs : InputDialogEventArgs
 
     internal bool Confirmation { get; private set; }
 
+    /// <summary>
+    /// Sets the confirmation result returned to JavaScript.
+    /// </summary>
+    /// <param name="confirmation">The value returned by the JavaScript confirm dialog.</param>
     public void SetDialogConfirmation(bool confirmation)
     {
         Confirmation = confirmation;
@@ -45,6 +67,9 @@ public sealed class ConfirmInputDialogEventArgs : InputDialogEventArgs
     }
 }
 
+/// <summary>
+/// Provides data for a JavaScript prompt dialog request.
+/// </summary>
 public sealed class PromptInputDialogEventArgs : InputDialogEventArgs
 {
     internal PromptInputDialogEventArgs(PhotinoWindow window, string message, string defaultInput)
@@ -53,10 +78,17 @@ public sealed class PromptInputDialogEventArgs : InputDialogEventArgs
         DefaultInput = defaultInput ?? string.Empty;
     }
 
+    /// <summary>
+    /// Gets the default prompt input supplied by JavaScript.
+    /// </summary>
     public string DefaultInput { get; }
 
     internal string Input { get; private set; }
 
+    /// <summary>
+    /// Sets the prompt input returned to JavaScript.
+    /// </summary>
+    /// <param name="input">The input value returned by the JavaScript prompt dialog.</param>
     public void SetDialogInput(string input)
     {
         Input = input ?? string.Empty;

--- a/Photino.NET/InputDialogEventArgs.cs
+++ b/Photino.NET/InputDialogEventArgs.cs
@@ -1,0 +1,65 @@
+namespace Photino.NET;
+
+public class InputDialogEventArgs : EventArgs
+{
+    internal InputDialogEventArgs(PhotinoWindow window, string message)
+    {
+        Window = window;
+        Message = message ?? string.Empty;
+    }
+
+    public PhotinoWindow Window { get; }
+
+    public string Message { get; }
+
+    public bool Handled { get; private set; }
+
+    internal bool Dismissed { get; private set; }
+
+    public void DismissDialog()
+    {
+        Handled = true;
+        Dismissed = true;
+    }
+
+    protected void MarkHandled()
+    {
+        Handled = true;
+        Dismissed = false;
+    }
+}
+
+public sealed class ConfirmInputDialogEventArgs : InputDialogEventArgs
+{
+    internal ConfirmInputDialogEventArgs(PhotinoWindow window, string message)
+        : base(window, message)
+    {
+    }
+
+    internal bool Confirmation { get; private set; }
+
+    public void SetDialogConfirmation(bool confirmation)
+    {
+        Confirmation = confirmation;
+        MarkHandled();
+    }
+}
+
+public sealed class PromptInputDialogEventArgs : InputDialogEventArgs
+{
+    internal PromptInputDialogEventArgs(PhotinoWindow window, string message, string defaultInput)
+        : base(window, message)
+    {
+        DefaultInput = defaultInput ?? string.Empty;
+    }
+
+    public string DefaultInput { get; }
+
+    internal string Input { get; private set; }
+
+    public void SetDialogInput(string input)
+    {
+        Input = input ?? string.Empty;
+        MarkHandled();
+    }
+}

--- a/Photino.NET/PhotinoDllImports.cs
+++ b/Photino.NET/PhotinoDllImports.cs
@@ -166,6 +166,10 @@ public partial class PhotinoWindow
 
     [LibraryImport(DLL_NAME, SetLastError = true)]
     [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    static partial void Photino_SetInputDialogInterceptionEnabled(IntPtr instance, [MarshalAs(UnmanagedType.I1)] bool enabled);
+
+    [LibraryImport(DLL_NAME, SetLastError = true)]
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     static partial void Photino_SetDevToolsEnabled(IntPtr instance, [MarshalAs(UnmanagedType.I1)] bool enabled);
 
     [LibraryImport(DLL_NAME, SetLastError = true)]

--- a/Photino.NET/PhotinoNativeDelegates.cs
+++ b/Photino.NET/PhotinoNativeDelegates.cs
@@ -14,6 +14,7 @@ namespace Photino.NET;
 [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate void CppMinimizedDelegate();
 [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate void CppMovedDelegate(int x, int y);
 [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate void CppWebMessageReceivedDelegate(string message);
+[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate int CppInputDialogRequestedDelegate(int kind, string message, string defaultInput, IntPtr responseBuffer, int responseBufferLength);
 [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] public delegate IntPtr CppWebResourceRequestedDelegate(string url, out int outNumBytes, out string outContentType);
 
 //These are sent in during the request

--- a/Photino.NET/PhotinoNativeParameters.cs
+++ b/Photino.NET/PhotinoNativeParameters.cs
@@ -79,6 +79,9 @@ internal struct PhotinoNativeParameters
     ///<summary>SET BY PHOTINIWINDOW CONSTRUCTOR</summary>
     [MarshalAs(UnmanagedType.FunctionPtr)] internal CppWebMessageReceivedDelegate WebMessageReceivedHandler;
 
+    ///<summary>SET BY PHOTINOWINDOW CONSTRUCTOR</summary>
+    [MarshalAs(UnmanagedType.FunctionPtr)] internal CppInputDialogRequestedDelegate InputDialogRequestedHandler;
+
     ///<summary>OPTIONAL: Names of custom URL Schemes. e.g. 'app', 'custom'. Array length must be 16. Default is none.</summary>
     [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.LPStr, SizeConst = 16)]
     internal string[] CustomSchemeNames;

--- a/Photino.NET/PhotinoNetDelegates.cs
+++ b/Photino.NET/PhotinoNetDelegates.cs
@@ -201,7 +201,24 @@ public partial class PhotinoWindow
     /// <summary>
     /// Occurs when JavaScript requests an alert, confirm, or prompt dialog.
     /// </summary>
-    public event EventHandler<InputDialogEventArgs> InputDialogRequested;
+    public event EventHandler<InputDialogEventArgs> InputDialogRequested
+    {
+        add
+        {
+            var wasEmpty = _inputDialogRequested is null;
+            _inputDialogRequested += value;
+            if (wasEmpty && _inputDialogRequested is not null)
+                SetInputDialogInterceptionEnabled(true);
+        }
+        remove
+        {
+            _inputDialogRequested -= value;
+            if (_inputDialogRequested is null)
+                SetInputDialogInterceptionEnabled(false);
+        }
+    }
+
+    private EventHandler<InputDialogEventArgs> _inputDialogRequested;
 
     /// <summary>
     /// Registers user-defined handler methods to receive callbacks when JavaScript requests alert, confirm, or prompt dialogs.
@@ -228,7 +245,7 @@ public partial class PhotinoWindow
             _ => new InputDialogEventArgs(this, message)
         };
 
-        InputDialogRequested?.Invoke(this, args);
+        _inputDialogRequested?.Invoke(this, args);
         if (!args.Handled)
             return 0;
 
@@ -261,6 +278,14 @@ public partial class PhotinoWindow
         }
 
         return flags;
+    }
+
+    private void SetInputDialogInterceptionEnabled(bool enabled)
+    {
+        if (_nativeInstance == IntPtr.Zero)
+            return;
+
+        Invoke(() => Photino_SetInputDialogInterceptionEnabled(_nativeInstance, enabled));
     }
 
     public delegate bool NetClosingDelegate(object sender, EventArgs e);

--- a/Photino.NET/PhotinoNetDelegates.cs
+++ b/Photino.NET/PhotinoNetDelegates.cs
@@ -198,6 +198,9 @@ public partial class PhotinoWindow
         WebMessageReceived?.Invoke(this, message);
     }
 
+    /// <summary>
+    /// Occurs when JavaScript requests an alert, confirm, or prompt dialog.
+    /// </summary>
     public event EventHandler<InputDialogEventArgs> InputDialogRequested;
 
     /// <summary>

--- a/Photino.NET/PhotinoNetDelegates.cs
+++ b/Photino.NET/PhotinoNetDelegates.cs
@@ -5,6 +5,9 @@ namespace Photino.NET;
 
 public partial class PhotinoWindow
 {
+    private const int InputDialogKindConfirm = 1;
+    private const int InputDialogKindPrompt = 2;
+
     //FLUENT EVENT HANDLER REGISTRATION
     public event EventHandler<Point> WindowLocationChanged;
 
@@ -193,6 +196,68 @@ public partial class PhotinoWindow
     internal void OnWebMessageReceived(string message)
     {
         WebMessageReceived?.Invoke(this, message);
+    }
+
+    public event EventHandler<InputDialogEventArgs> InputDialogRequested;
+
+    /// <summary>
+    /// Registers user-defined handler methods to receive callbacks when JavaScript requests alert, confirm, or prompt dialogs.
+    /// </summary>
+    /// <returns>
+    /// Returns the current <see cref="PhotinoWindow"/> instance.
+    /// </returns>
+    /// <param name="handler"><see cref="EventHandler{InputDialogEventArgs}"/></param>
+    public PhotinoWindow RegisterInputDialogRequestedHandler(EventHandler<InputDialogEventArgs> handler)
+    {
+        InputDialogRequested += handler;
+        return this;
+    }
+
+    /// <summary>
+    /// Invokes registered user-defined handler methods when JavaScript requests an input dialog.
+    /// </summary>
+    internal int OnInputDialogRequested(int kind, string message, string defaultInput, IntPtr responseBuffer, int responseBufferLength)
+    {
+        var args = kind switch
+        {
+            InputDialogKindConfirm => new ConfirmInputDialogEventArgs(this, message),
+            InputDialogKindPrompt => new PromptInputDialogEventArgs(this, message, defaultInput),
+            _ => new InputDialogEventArgs(this, message)
+        };
+
+        InputDialogRequested?.Invoke(this, args);
+        if (!args.Handled)
+            return 0;
+
+        var flags = 1;
+        if (args.Dismissed)
+            flags |= 2;
+
+        if (args is ConfirmInputDialogEventArgs { Confirmation: true })
+            flags |= 4;
+
+        if (args is PromptInputDialogEventArgs promptArgs &&
+            !promptArgs.Dismissed &&
+            responseBuffer != IntPtr.Zero &&
+            responseBufferLength > 0)
+        {
+            if (IsWindowsPlatform)
+            {
+                var length = Math.Min(promptArgs.Input.Length, responseBufferLength - 1);
+                var chars = promptArgs.Input.AsSpan(0, length).ToArray();
+                Marshal.Copy(chars, 0, responseBuffer, chars.Length);
+                Marshal.WriteInt16(responseBuffer, chars.Length * sizeof(char), 0);
+            }
+            else
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(promptArgs.Input);
+                var byteCount = Math.Min(bytes.Length, responseBufferLength - 1);
+                Marshal.Copy(bytes, 0, responseBuffer, byteCount);
+                Marshal.WriteByte(responseBuffer, byteCount, 0);
+            }
+        }
+
+        return flags;
     }
 
     public delegate bool NetClosingDelegate(object sender, EventArgs e);

--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -1239,7 +1239,7 @@ public partial class PhotinoWindow
     {
         get
         {
-            return InputDialogRequested;
+            return _inputDialogRequested;
         }
         set
         {
@@ -2420,7 +2420,12 @@ public partial class PhotinoWindow
                 else if (IsMacOsPlatform)
                     Invoke(() => Photino_register_mac());
 
-                Invoke(() => _nativeInstance = Photino_ctor(ref _startupParameters));
+                Invoke(() =>
+                {
+                    _nativeInstance = Photino_ctor(ref _startupParameters);
+                    if (_inputDialogRequested is not null)
+                        Photino_SetInputDialogInterceptionEnabled(_nativeInstance, true);
+                });
             }
             catch (Exception ex)
             {

--- a/Photino.NET/PhotinoWindow.NET.cs
+++ b/Photino.NET/PhotinoWindow.NET.cs
@@ -1231,6 +1231,23 @@ public partial class PhotinoWindow
     }
 
     /// <summary>
+    /// Gets or sets handlers for InputDialogRequested event.
+    /// Set assigns a new handler to the event.
+    /// </summary>
+    /// <seealso cref="InputDialogRequested"/>
+    public EventHandler<InputDialogEventArgs> InputDialogRequestedHandler
+    {
+        get
+        {
+            return InputDialogRequested;
+        }
+        set
+        {
+            InputDialogRequested += value;
+        }
+    }
+
+    /// <summary>
     /// Gets or Sets the native window width in pixels.
     /// Default is 0.
     /// </summary>
@@ -1483,6 +1500,7 @@ public partial class PhotinoWindow
         _startupParameters.FocusInHandler = OnFocusIn;
         _startupParameters.FocusOutHandler = OnFocusOut;
         _startupParameters.WebMessageReceivedHandler = OnWebMessageReceived;
+        _startupParameters.InputDialogRequestedHandler = OnInputDialogRequested;
         _startupParameters.CustomSchemeHandler = OnCustomScheme;
     }
 


### PR DESCRIPTION
## Summary
- Adds InputDialogRequested for JavaScript alert, confirm, and prompt dialogs
- Adds polymorphic event args: InputDialogEventArgs, ConfirmInputDialogEventArgs, and PromptInputDialogEventArgs
- Adds dismiss, confirmation, and prompt input response APIs for handlers

## Related
- Companion native callback PR: tryphotino/photino.Native#180

## Validation
- dotnet build Photino.NET.sln --no-restore
- dotnet build Photino.Test\\Photino.Test.csproj --no-restore from photino.Native

## Notes
- Native C++ build was not completed locally because the installed MSBuild cannot find the required v143 platform toolset.