### PR TITLE
Add .NET 10 target framework

### DIFF
--- a/Photino.NET/Photino.NET.csproj
+++ b/Photino.NET/Photino.NET.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<Authors>TryPhotino</Authors>
 		<Company>TryPhotino</Company>
-		<Description>.NET 8/9 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</Description>
+		<Description>.NET 8/9/10 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</Description>
 		<GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);SetPackageVersion</GenerateNuspecDependsOn>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<PackageDescription>.NET 8/9 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</PackageDescription>
+		<PackageDescription>.NET 8/9/10 app that opens native OS windows hosting web UI on Windows, Mac, and Linux (without Blazor support)</PackageDescription>
 		<PackageId>Photino.NET</PackageId>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Product>Photino.NET</Product>
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>true</ImplicitUsings>
 		<LangVersion>latest</LangVersion>
 		<OutputType>Library</OutputType>

--- a/azure-pipelines-photino.net-dev.yml
+++ b/azure-pipelines-photino.net-dev.yml
@@ -18,10 +18,10 @@ jobs:
 
       steps:
           - task: UseDotNet@2
-            displayName: "Use .NET 9 sdk"
+            displayName: "Use .NET 10 sdk"
             inputs:
                 packageType: sdk
-                version: 9.0.x
+                version: 10.0.x
                 installationPath: $(Agent.ToolsDirectory)/dotnet
 
           - task: CmdLine@2

--- a/azure-pipelines-photino.net-prod.yml
+++ b/azure-pipelines-photino.net-prod.yml
@@ -18,10 +18,10 @@ jobs:
 
       steps:
           - task: UseDotNet@2
-            displayName: "Use .NET 9 sdk"
+            displayName: "Use .NET 10 sdk"
             inputs:
                 packageType: sdk
-                version: 9.0.x
+                version: 10.0.x
                 installationPath: $(Agent.ToolsDirectory)/dotnet
 
           #Build and Create NuGet package


### PR DESCRIPTION
Added net10.0 to TargetFrameworks alongside net8.0/net9.0, updated the package descriptions, and bumped the Azure Pipelines build SDK to 10.0.x.